### PR TITLE
Migrate hosting from Netlify to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,48 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## What

Migrates hosting from Netlify to GitHub Pages, served at **classic.spaceninja.com**.

Adds `.github/workflows/deploy.yml` using GitHub's first-party Pages actions:
- `actions/configure-pages@v5`
- `actions/upload-pages-artifact@v3`
- `actions/deploy-pages@v4`

No `gh-pages` branch needed — the built artifact uploads directly to Pages infrastructure.

## Already done outside this PR

- Pages enabled with `build_type=workflow` and `cname=classic.spaceninja.com` via the API.
- DNS record created in Cloudflare: `classic.spaceninja.com CNAME → spaceninja.github.io` (DNS-only).

## After merge

The workflow runs automatically on the merge push. Once it deploys and GitHub provisions the Let's Encrypt cert, Enforce HTTPS gets enabled. The Netlify site can then be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)